### PR TITLE
remove any white spaces that are added to the key string. 

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -6,7 +6,7 @@ def open_file(filepath):
         return infile.read()
 
 
-openai.api_key = open_file('openaiapikey.txt')
+openai.api_key = open_file('openaiapikey.txt').strip()
 
 
 def gpt3_completion(prompt, engine='text-davinci-002', temp=0.7, top_p=1.0, tokens=400, freq_pen=0.0, pres_pen=0.0, stop=['JAX:', 'USER:']):

--- a/embedding.py
+++ b/embedding.py
@@ -19,7 +19,7 @@ def similarity(v1, v2):  # return dot product of two vectors
     return np.dot(v1, v2)
 
 
-openai.api_key = open_file('openaiapikey.txt')
+openai.api_key = open_file('openaiapikey.txt').strip()
 
 
 def match_class(vector, classes):

--- a/hello_world.py
+++ b/hello_world.py
@@ -6,7 +6,7 @@ def open_file(filepath):
         return infile.read()
 
 
-openai.api_key = open_file('openaiapikey.txt')
+openai.api_key = open_file('openaiapikey.txt').strip()
 
 
 def gpt3_completion(prompt, engine='text-davinci-002', temp=0.7, top_p=1.0, tokens=400, freq_pen=0.0, pres_pen=0.0, stop=['<<END>>']):


### PR DESCRIPTION
An IDE/text editor or the programmer may add a white space to the end of the key string. This will break the code. By Adding `.strip()` we avoid this issue.  